### PR TITLE
more accurate eta and size estimation in --progress 3

### DIFF
--- a/Source/App/app_process_cmd.c
+++ b/Source/App/app_process_cmd.c
@@ -946,18 +946,16 @@ void process_output_stream_buffer(EncChannel *channel, EncApp *enc_app, int32_t 
                 (double)app_cfg->config.frame_rate_denominator;
 
             // Patman's progress variables
-            const double ete        = app_cfg->performance_context.total_encode_time;
-            int ete_r               = round(ete);
-            int ete_hours           = ete_r / 3600;
-            int ete_minutes         = (ete_r - (ete_hours * 3600)) / 60;
-            int ete_seconds         = ete_r - (ete_hours * 3600) - (ete_minutes * 60);
-            const double eta        = (app_cfg->performance_context.total_encode_time / app_cfg->frames_encoded) * (app_cfg->frames_to_be_encoded - app_cfg->frames_encoded);
-            int eta_r               = round(eta);
-            int eta_hours           = eta_r / 3600;
-            int eta_minutes         = (eta_r - (eta_hours * 3600)) / 60;
-            int eta_seconds         = eta_r - (eta_hours * 3600) - (eta_minutes * 60);
+            const int ete           = (int)app_cfg->performance_context.total_encode_time;
+            int ete_hours           = ete / 3600;
+            int ete_minutes         = (ete % 3600) / 60;
+            int ete_seconds         = ete % 60;
+            const int eta           = (int)((app_cfg->frames_to_be_encoded - *frame_count) / fps);
+            int eta_hours           = eta / 3600;
+            int eta_minutes         = (eta % 3600) / 60;
+            int eta_seconds         = eta % 60;
             double size             = ((double)app_cfg->performance_context.byte_count / 1000000);
-            double estsz            = ((double)app_cfg->performance_context.byte_count * app_cfg->frames_to_be_encoded / (app_cfg->frames_encoded * 1000) / 1000);
+            double estsz            = size / *frame_count * app_cfg->frames_to_be_encoded;
 
             switch (app_cfg->progress) {
             case 0: break;
@@ -1101,18 +1099,16 @@ void process_output_stream_buffer(EncChannel *channel, EncApp *enc_app, int32_t 
                 (double)app_cfg->config.frame_rate_denominator;
 
             // Patman's progress variables
-            const double ete        = app_cfg->performance_context.total_encode_time;
-            int ete_r               = round(ete);
-            int ete_hours           = ete_r / 3600;
-            int ete_minutes         = (ete_r - (ete_hours * 3600)) / 60;
-            int ete_seconds         = ete_r - (ete_hours * 3600) - (ete_minutes * 60);
-            const double eta        = (app_cfg->performance_context.total_encode_time / app_cfg->frames_encoded) * (app_cfg->frames_to_be_encoded - app_cfg->frames_encoded);
-            int eta_r               = round(eta);
-            int eta_hours           = eta_r / 3600;
-            int eta_minutes         = (eta_r - (eta_hours * 3600)) / 60;
-            int eta_seconds         = eta_r - (eta_hours * 3600) - (eta_minutes * 60);
+            const int ete           = (ing)app_cfg->performance_context.total_encode_time;
+            int ete_hours           = ete / 3600;
+            int ete_minutes         = (ete % 3600) / 60;
+            int ete_seconds         = ete % 60;
+            const int eta           = (int)((app_cfg->frames_to_be_encoded - *frame_count) / fps);
+            int eta_hours           = eta / 3600;
+            int eta_minutes         = (eta % 3600) / 60;
+            int eta_seconds         = eta % 60;
             double size             = ((double)app_cfg->performance_context.byte_count / 1000000);
-            double estsz            = ((double)app_cfg->performance_context.byte_count * app_cfg->frames_to_be_encoded / (app_cfg->frames_encoded * 1000) / 1000);
+            double estsz            = size / *frame_count * app_cfg->frames_to_be_encoded;
 
             switch (app_cfg->progress) {
             case 0: break;


### PR DESCRIPTION
I noticed that when encoding with StaxRip, the eta gets to -0:00:00 while there's still encoding happening.

Currently, `--progress 3` eta and size estimation look like this for small frame counts:
`Encoding:   17/55 Frames @ 2.39 fps | 1787.38 kb/s | Time: 0:00:07 [-0:00:00] | Size: 0.51 MB [0.51 MB]`

Basically, eta is 0 from the beginning and size estimation is equal to current size.

By using `*frame_count` instead of `app_cfg->frames_encoded`, eta and size estimation look more correct:
`Encoding:    9/55 Frames @ 1.57 fps | 1136.78 kb/s | Time: 0:00:05 [-0:00:29] | Size: 0.33 MB [1.99 MB]`

Also, set `ete` and `eta` to integer right away (doesn't seem like floating point is needed here at all), and simplified their calculation. Getting hours, minutes, and seconds with integer math instead now.

Calculation of `estsz` is based on existing `size` variable as well now.