### PR TITLE
Replace archived project in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ One way to get involved is to use SVT-AV1-PSY in your own AV1 encoding projects,
 **Projects Featuring SVT-AV1-PSY:**
 
 - [Aviator](https://github.com/gianni-rosato/aviator) ~ an AV1 encoding GUI by @gianni-rosato
-- [rAV1ator CLI](https://github.com/gianni-rosato/rav1ator-cli) ~ a TUI for video encoding with Av1an by @gianni-rosato
+- [rAV1ator CLI](https://github.com/ultimaxx/rav1ator-cli) ~ a TUI for video encoding with Av1an by @ultimaxx
 - [SVT-AV1-PSY on the AUR](https://aur.archlinux.org/packages/svt-av1-psy-git) ~ by @BlueSwordM
 - [SVT-AV1-PSY in CachyOS](https://github.com/CachyOS/CachyOS-PKGBUILDS/pull/144) ~ by @BlueSwordM
 - [Handbrake Builds](https://github.com/Nj0be/HandBrake-SVT-AV1-PSY) ~ by @Nj0be


### PR DESCRIPTION
Hi, I noticed that rAV1ator has been archived and its readme points to ultimaxx's fork.

I also noticed that Av1ador has been archived as well but it doesn't point to any forks so I didn't remove it, but I can if you think it should be removed.